### PR TITLE
Proofreading fixes

### DIFF
--- a/module-1.ipynb
+++ b/module-1.ipynb
@@ -44,7 +44,7 @@
     "\n",
     "- Python's applicability to problems in science was bolstered by NumPy\n",
     "    - Released in 2006\n",
-    "    - Built on the capabilities of Numeric, which appeard in 1995\n",
+    "    - Built on the capabilities of Numeric, which appeared in 1995\n",
     "    - Technically part of the larger SciPy ecosystem, but can be installed independently"
    ]
   },
@@ -127,7 +127,7 @@
    "source": [
     "- In addition to functionality, NumPy provides better performance by\n",
     "    - Expressing `ndarray` as a type-homogenous, densely-packed memory representation vs `List`'s dynamic arrays\n",
-    "    - Implementing underlying routines in C or Fortran, with conveient Python wrappers\n",
+    "    - Implementing underlying routines in C or Fortran, with convenient Python wrappers\n",
     "    - Reusing well-tuned libraries like BLAS for linear algebra"
    ]
   },
@@ -157,7 +157,7 @@
     "collapsed": true
    },
    "source": [
-    "As `ndarray` is NumPy's essential data structure, `DataFrame` and `series` are pandas'.\n",
+    "As `ndarray` is NumPy's essential data structure, `DataFrame` and `Series` are pandas'.\n",
     " \n",
     "`Series`: _\"One-dimensional ndarray with axis labels (including time series).\"_"
    ]
@@ -178,7 +178,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Series often ultimately represent columns in a data frame, and have implicit indexes (the position of the element in the array, by default) that are used when concatenating multiple series into a data frame.\n",
+    "Series often ultimately represent columns in a data frame, and have implicit indices (the position of the element in the array, by default) that are used when concatenating multiple series into a data frame.\n",
     "\n",
     "`DataFrame`: _\"Two-dimensional size-mutable, potentially heterogeneous tabular data structure with labeled axes (rows and columns).\"_"
    ]
@@ -285,11 +285,11 @@
    "source": [
     "### Jupyter\n",
     "\n",
-    "- Jupyter is the evolution of the iPython project\n",
-    "    - iPython provides an interactive Python shell with facilities for code and text editing, data visualization, and compute parallelism\n",
+    "- Jupyter is the evolution of the IPython project\n",
+    "    - IPython provides an interactive Python shell with facilities for code and text editing, data visualization, and compute parallelism\n",
     "    - Similar to Mathematica (or Matlab's Live Editor) notebooks\n",
-    "    - iPython Notebook uses a web browser interface\n",
-    "- Extends iPython to support \"over 40\" programming languages -- not just Python\n",
+    "    - IPython Notebook uses a web browser interface\n",
+    "- Extends IPython to support \"over 40\" programming languages -- not just Python\n",
     "- Browser environment\n",
     "    - Home tab\n",
     "        - _Files_\n",

--- a/module-2.ipynb
+++ b/module-2.ipynb
@@ -60,7 +60,7 @@
     ]
    },
    "source": [
-    "We can also obtain an image directly from the internet and display in with Python code:"
+    "We can also obtain an image directly from the Internet and display in with Python code:"
    ]
   },
   {
@@ -87,7 +87,7 @@
     ]
    },
    "source": [
-    "The `netCDF4` package provide OpenDAP client capabilities. Here we use it to obtain data via an OpenDAP server at NSIDC:"
+    "The `netCDF4` package provide OPeNDAP client capabilities. Here we use it to obtain data via an OPeNDAP server at NSIDC:"
    ]
   },
   {
@@ -597,7 +597,7 @@
     ]
    },
    "source": [
-    "Instances of the `Variable` class (like our `latitude` object) from `netCDF` behave like multidimensional arrays, similar to NumPy's `ndarray`. So, we can access elements with the familiar `[]` bracket notation. Since we know that `latitude` is 720 x 720, as we expect:"
+    "Instances of the `Variable` class (like our `latitude` object) from `netCDF4` behave like multidimensional arrays, similar to NumPy's `ndarray`. So, we can access elements with the familiar `[]` bracket notation. Since we know that `latitude` is 720 x 720, as we expect:"
    ]
   },
   {
@@ -977,11 +977,11 @@
     ]
    },
    "source": [
-    "### Subsetting data with OpenDAP\n",
+    "### Subsetting data with OPeNDAP\n",
     "\n",
-    "One benefit to using OpenDAP for data acess is that data can be subsetted prior to download, to avoid the transfer and storage of data one is not interested in.\n",
+    "One benefit to using OPeNDAP for data access is that data can be subsetted prior to download, to avoid the transfer and storage of data one is not interested in.\n",
     "\n",
-    "NSIDC's [OPeNDAP Server Dataset Access Form](http://opendap.apps.nsidc.org/opendap/DATASETS/nsidc0530_MEASURES_nhsnow_daily25/2012/nhtsd25e2_20120101_v01r01.nc.html) for this data gives some guidance on subsetting the data. For starters, let's restrict our query to the three variables -- Latitude, Longitude, and Merged Snow Cover Extent -- that we are interested in. When we tick the checkboxes for _latitude_, _longitude_, and _merged_snow_cover_extent_, the URL shown in the _Data URL_ field is updated to:\n",
+    "NSIDC's [OPeNDAP Server Dataset Access Form](http://opendap.apps.nsidc.org/opendap/DATASETS/nsidc0530_MEASURES_nhsnow_daily25/2012/nhtsd25e2_20120101_v01r01.nc.html) for this data gives some guidance on subsetting the data. For starters, let's restrict our query to the three variables -- Latitude, Longitude, and Merged Snow Cover Extent -- that we are interested in. When we tick the checkboxes for _latitude_, _longitude_, and *merged_snow_cover_extent*, the URL shown in the _Data URL_ field is updated to:\n",
     "\n",
     "`http://opendap.apps.nsidc.org:80/opendap/DATASETS/nsidc0530_MEASURES_nhsnow_daily25/2012/nhtsd25e2_20120101_v01r01.nc?latitude[0:1:719][0:1:719],longitude[0:1:719][0:1:719],merged_snow_cover_extent[0:1:0][0:1:719][0:1:719]`\n",
     "\n",
@@ -1111,7 +1111,7 @@
     ]
    },
    "source": [
-    "Now let's add contraints our OpenDAP URL to select just the rows and columns that we think correspond to Iceland. The OpenDAP constraints are given in `lower_bound:stride:upper_bound` form:"
+    "Now let's add constraints our OPeNDAP URL to select just the rows and columns that we think correspond to Iceland. The OPeNDAP constraints are given in `lower_bound:stride:upper_bound` form:"
    ]
   },
   {

--- a/module-3.ipynb
+++ b/module-3.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "## Viewing geolocated data\n",
     "\n",
-    "In Module 2, we retrieved NSIDC snow-cover data in the northern hemisphere from an OpenDAP server. Let's pull that data again for use in this notebook:"
+    "In Module 2, we retrieved NSIDC snow-cover data in the northern hemisphere from an OPeNDAP server. Let's pull that data again for use in this notebook:"
    ]
   },
   {
@@ -280,7 +280,7 @@
     ]
    },
    "source": [
-    "At the end of Module 2, we tried to use OpenDAP to retrieve data only in the area of Iceland. Let's execute that query again:"
+    "At the end of Module 2, we tried to use OPeNDAP to retrieve data only in the area of Iceland. Let's execute that query again:"
    ]
   },
   {

--- a/module-4.ipynb
+++ b/module-4.ipynb
@@ -62,7 +62,7 @@
     ]
    },
    "source": [
-    "Using the URL above, we can find the OpenDAP (DODS) endpoint and access it via the netCDF4 python package:"
+    "Using the URL above, we can find the OPeNDAP (DODS) endpoint and access it via the netCDF4 python package:"
    ]
   },
   {
@@ -89,7 +89,7 @@
     ]
    },
    "source": [
-    "Open and connect the OpenDAP endpoint:"
+    "Open and connect the OPeNDAP endpoint:"
    ]
   },
   {
@@ -211,7 +211,7 @@
     ]
    },
    "source": [
-    "Let's attatch some Python variables to some of the dataset's metadata variables:"
+    "Let's attach some Python variables to some of the dataset's metadata variables:"
    ]
   },
   {
@@ -337,7 +337,7 @@
     ]
    },
    "source": [
-    "Let's attatch to the dataset's main CDR variable and get an idea of its contents:"
+    "Let's attach to the dataset's main CDR variable and get an idea of its contents:"
    ]
   },
   {
@@ -566,7 +566,7 @@
     ]
    },
    "source": [
-    "We'd like to work analytically, not just visually, with these time-dependent data. To do so, we'll need to get our hands on time data matchign the snow-cover data.\n",
+    "We'd like to work analytically, not just visually, with these time-dependent data. To do so, we'll need to get our hands on time data matching the snow cover data.\n",
     "\n",
     "Our dataset does provide a `time` variable:"
    ]
@@ -736,7 +736,7 @@
     "\n",
     "      s = pd.Series(data, index=index)\n",
     "\n",
-    "Let's create a `Series` object from our snow-cover and associated time data:"
+    "Let's create a `Series` object from our snow cover and associated time data:"
    ]
   },
   {
@@ -1104,7 +1104,7 @@
     ]
    },
    "source": [
-    "On what day did that maxium occur?"
+    "On what day did that maximum occur?"
    ]
   },
   {
@@ -1367,7 +1367,7 @@
    "source": [
     "But we can improve our analysis.\n",
     "\n",
-    "In this dataset, each indexed snow-cover grid represents a week of data. So the grid with index '1966-10-31' represents the _week_ beginning on that day _through_ 1966-11-06, and some (most!) of the days in that week actually fall in November and should be used to compute November's mean.\n",
+    "In this dataset, each indexed snow cover grid represents a week of data. So the grid with index '1966-10-31' represents the _week_ beginning on that day _through_ 1966-11-06, and some (most!) of the days in that week actually fall in November and should be used to compute November's mean.\n",
     "\n",
     "Let's resample our time series again, this time using pandas' `ffill()` feature to **f**orward **fill** the missing dates between each week-start date with the provided value. For example, `ffill()` will create the missing dates 1996-11-01 through 1966-11-06 with the value provided for the week starting 1996-10-31."
    ]
@@ -1667,7 +1667,7 @@
     ]
    },
    "source": [
-    "Let's create a simple `DataFrame` from our monthly data using March and its associated ranks. The `march` series contains the actual snow-cover values, and the `rank` series contains the rankings but, if we look at the heads of both series, we see that the indexes are the same:"
+    "Let's create a simple `DataFrame` from our monthly data using March and its associated ranks. The `march` series contains the actual snow cover values, and the `rank` series contains the rankings but, if we look at the heads of both series, we see that the indices are the same:"
    ]
   },
   {
@@ -1789,7 +1789,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It's nice to be able to use named columns instead of trying to remember numeric indexes as one might in, for example, pure NumPy. Here we get the same result, in a single statement, as we obtained previously by making separate queries on the original snow-cover and rank series."
+    "It's nice to be able to use named columns instead of trying to remember numeric indices as one might in, for example, pure NumPy. Here we get the same result, in a single statement, as we obtained previously by making separate queries on the original snow cover and rank series."
    ]
   },
   {


### PR DESCRIPTION
* fix spelling and capitalization issues

* OPeNDAP has pretty weird capitalization - http://www.opendap.org/

* the pandas `Series` class is capitalized

* include the 4 when referring to the netCDF4 module

* fix italics when underscores are used in the
  italics (`*merged_snow_cover_extent*` instead of
  `_merged_snow_cover_extent_`)

* only hyphenate the adjective "snow-covered", otherwise, use "snow
  cover" - http://www.grammarbook.com/punctuation/hyphens.asp

* indexes -> indices; "indexes" is more common in general North American
  usage, but "indices" is preferred in mathematical and technical
  contexts - http://grammarist.com/usage/indexes-indices/

* iPython -> IPython