### PR TITLE
Add plotly to list of python modules to install

### DIFF
--- a/module-0.ipynb
+++ b/module-0.ipynb
@@ -76,6 +76,7 @@
     "\n",
     "```\n",
     "conda install -y basemap netCDF4 pandas=0.18.0\n",
+    "pip install plotly\n",
     "```\n",
     "\n",
     "You will also need a working `unzip` program. Please install it via your package manager or other means if you do not already have it.\n",


### PR DESCRIPTION
The conda package for plotly is hosted on nsidc's account, so the user would have to configure anaconda to trust our repos and it looks like that's not in the instructions already, so just using `pip` seems better to me.