### PR TITLE
Touchups

### DIFF
--- a/module-4.ipynb
+++ b/module-4.ipynb
@@ -373,7 +373,7 @@
     "from ipywidgets import interact\n",
     "import ipywidgets as widgets\n",
     "\n",
-    "@interact(index=widgets.IntSlider(min=0, max=2573, step=4, value=0))\n",
+    "@interact(index=widgets.IntSlider(min=0, max=2573, step=4, value=0, continuous_update=False))\n",
     "def show_it(index=0):\n",
     "    plt.figure(figsize=(10, 10))\n",
     "    plt.imshow(all_data[index, :, :], interpolation='nearest', cmap='Blues')"
@@ -440,7 +440,7 @@
    },
    "outputs": [],
    "source": [
-    "@interact(index=widgets.IntSlider(min=0, max=2573, step=4, value=0))\n",
+    "@interact(index=widgets.IntSlider(min=0, max=2573, step=4, value=0, continuous_update=False))\n",
     "def show_it(index=0):\n",
     "    plt.figure(figsize=(10, 10))\n",
     "    plt.imshow(all_data[index, :, :] * area[:], interpolation='nearest', cmap='plasma')"

--- a/module-4.ipynb
+++ b/module-4.ipynb
@@ -1888,7 +1888,7 @@
     ]
    },
    "source": [
-    "We can use [`unstack()`](http://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.unstack.html) on the months' levels to get an index of years, with columns of months. This pulls the specificed index (level 1 is month) out and spreads it as columns under the existing _snowcover_ column index:"
+    "We can use [`unstack()`](http://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.unstack.html) on the months' level to get an index of years, with columns of months. This pulls the specificed index (level 1 is month) out and spreads it as columns under the existing _snowcover_ column index:"
    ]
   },
   {


### PR DESCRIPTION
	Change sliders to use continuous_update=False

 When we have a lot of values, continuous_update on can look messy and
clunky.  Setting to False, only updates the images after the user has
released the slider.


Typo: months' levels => months' level	